### PR TITLE
feat: clear UDC before launching char device (#50)

### DIFF
--- a/app/src/main/res/raw/create_char_devices.sh
+++ b/app/src/main/res/raw/create_char_devices.sh
@@ -33,6 +33,9 @@ fi
 
 echo "USB_GADGET_PATH = ${USB_GADGET_PATH}"
 
+# Disable gadget (temporarily)
+echo "" > "${USB_GADGET_PATH}/UDC"
+
 # Other paths
 CONFIGS_PATH="${USB_GADGET_PATH}/configs/b.1/"
 KB_FUNCTION_PATH="${USB_GADGET_PATH}/functions/hid.keyboard"


### PR DESCRIPTION
Based on the workaround mentioned by @szescxz.
The app (HID Gadget) does the following when disabling a gadget device:
```
echo "" > /config/usb_gadget/g1//UDC
```
This does appear to fix the issue (#50) on my Xiaomi 13 Ultra running AOSP.
I also tested this command using a regulard terminal interface; it also works.

The UDC value gets collected at the script's first line, and the UDC also gets overwritten at the very end.

While more testing is required on end devices, I hereby propose for this change to be included in the next release.